### PR TITLE
[NO_ISSEUE] CustomColor 에 문서화 주석 추가

### DIFF
--- a/HunnitLog/HunnitLog/Colors.xcassets/Grey.colorset/Contents.json
+++ b/HunnitLog/HunnitLog/Colors.xcassets/Grey.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.796",
-          "green" : "0.796",
-          "red" : "0.753"
+          "blue" : "203",
+          "green" : "203",
+          "red" : "192"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.796",
-          "green" : "0.796",
-          "red" : "0.753"
+          "blue" : "203",
+          "green" : "203",
+          "red" : "192"
         }
       },
       "idiom" : "universal"

--- a/HunnitLog/HunnitLog/Colors.xcassets/bgColor.colorset/Contents.json
+++ b/HunnitLog/HunnitLog/Colors.xcassets/bgColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.980",
-          "green" : "0.980",
-          "red" : "0.973"
+          "blue" : "250",
+          "green" : "250",
+          "red" : "248"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.980",
-          "green" : "0.980",
-          "red" : "0.973"
+          "blue" : "250",
+          "green" : "250",
+          "red" : "248"
         }
       },
       "idiom" : "universal"

--- a/HunnitLog/HunnitLog/Colors.xcassets/black.colorset/Contents.json
+++ b/HunnitLog/HunnitLog/Colors.xcassets/black.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "67",
+          "green" : "67",
+          "red" : "37"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.263",
+          "green" : "0.263",
+          "red" : "0.145"
         }
       },
       "idiom" : "universal"

--- a/HunnitLog/HunnitLog/Colors.xcassets/coolGrey.colorset/Contents.json
+++ b/HunnitLog/HunnitLog/Colors.xcassets/coolGrey.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.639",
-          "green" : "0.639",
-          "red" : "0.580"
+          "blue" : "163",
+          "green" : "163",
+          "red" : "148"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.639",
-          "green" : "0.639",
-          "red" : "0.580"
+          "blue" : "163",
+          "green" : "163",
+          "red" : "148"
         }
       },
       "idiom" : "universal"

--- a/HunnitLog/HunnitLog/Colors.xcassets/darkGrey.colorset/Contents.json
+++ b/HunnitLog/HunnitLog/Colors.xcassets/darkGrey.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.565",
-          "green" : "0.565",
-          "red" : "0.510"
+          "blue" : "144",
+          "green" : "144",
+          "red" : "130"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.565",
-          "green" : "0.565",
-          "red" : "0.510"
+          "blue" : "144",
+          "green" : "144",
+          "red" : "130"
         }
       },
       "idiom" : "universal"

--- a/HunnitLog/HunnitLog/Colors.xcassets/lightGrey.colorset/Contents.json
+++ b/HunnitLog/HunnitLog/Colors.xcassets/lightGrey.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.949",
-          "green" : "0.949",
-          "red" : "0.925"
+          "blue" : "242",
+          "green" : "242",
+          "red" : "236"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.949",
-          "green" : "0.949",
-          "red" : "0.925"
+          "blue" : "242",
+          "green" : "242",
+          "red" : "236"
         }
       },
       "idiom" : "universal"

--- a/HunnitLog/HunnitLog/Colors.xcassets/yellow.colorset/Contents.json
+++ b/HunnitLog/HunnitLog/Colors.xcassets/yellow.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.353",
-          "green" : "0.925",
-          "red" : "1.000"
+          "blue" : "90",
+          "green" : "236",
+          "red" : "255"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "90",
+          "green" : "236",
+          "red" : "255"
         }
       },
       "idiom" : "universal"

--- a/HunnitLog/HunnitLog/Resource/CustomColor.swift
+++ b/HunnitLog/HunnitLog/Resource/CustomColor.swift
@@ -8,12 +8,19 @@
 import SwiftUI
 
 struct CustomColor {
+    /// (248, 250, 250)
     static let bgColor = Color("bgColor")
-    static let gray = Color("Grey")
-    static let darkGray = Color("darkGrey")
-    static let coolGray = Color("coolGrey")
-    static let lightGray = Color("lightGrey")
-    static let yellow = Color("yellow")
+    /// (37, 67, 67)
     static let black = Color("black")
+    /// (148, 163, 163)
+    static let coolGray = Color("coolGrey")
+    /// (130, 144, 144)
+    static let darkGray = Color("darkGrey")
+    /// (192, 203, 203)
+    static let gray = Color("Grey")
+    /// (236, 242, 242)
+    static let lightGray = Color("lightGrey")
+    /// (255, 236, 90)
+    static let yellow = Color("yellow")
 }
 


### PR DESCRIPTION
## Description 
- 초이님께서 작업해주신 CustomColor 에 색상코드 관련 문서화 주석 추가하였습니다. 
- 색상코드 배열을 Color.xcassect 에 정의된 순서로 정렬하였습니다. 
- yellow 색상 darkMode 색 변경하였습니다.
- ~~black 색상의 경우 Color.black 을 사용하면 될 듯 하여 삭제했습니다.~~ black 색상이 그 블랙이 아니었군요, 수정하여두었습니다.

## 활용법
코드상에서 option click 할 경우 이렇게 주석이 노출되어 해당 색상의 코드값을 확인하기 편리합?니다. (동의해줘요)

<img width="387" alt="image" src="https://user-images.githubusercontent.com/11674980/100080742-8adbf400-2e89-11eb-9935-cf123d931c5d.png">

