### PR TITLE
[NON_ISSUE] 홈 top부분 뷰 UI 작성

### DIFF
--- a/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
+++ b/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		562F6978256A7A6D00C50C97 /* CustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6977256A7A6D00C50C97 /* CustomColor.swift */; };
 		562F697D256A7A8700C50C97 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 562F697C256A7A8700C50C97 /* Colors.xcassets */; };
+		562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6996256EC04800C50C97 /* RoundedBackground.swift */; };
 		630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */; };
 		630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD212566A38700CDFA50 /* RetrospectRow.swift */; };
 		630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */; };
@@ -51,6 +52,7 @@
 /* Begin PBXFileReference section */
 		562F6977256A7A6D00C50C97 /* CustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomColor.swift; sourceTree = "<group>"; };
 		562F697C256A7A8700C50C97 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Colors.xcassets; path = HunnitLog/Colors.xcassets; sourceTree = SOURCE_ROOT; };
+		562F6996256EC04800C50C97 /* RoundedBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBackground.swift; sourceTree = "<group>"; };
 		630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfableGrayLine.swift; sourceTree = "<group>"; };
 		630EBD212566A38700CDFA50 /* RetrospectRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectRow.swift; sourceTree = "<group>"; };
 		630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthFlagRow.swift; sourceTree = "<group>"; };
@@ -110,6 +112,14 @@
 				562F6977256A7A6D00C50C97 /* CustomColor.swift */,
 			);
 			path = Resource;
+			sourceTree = "<group>";
+		};
+		562F698D256EBF8400C50C97 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				562F6996256EC04800C50C97 /* RoundedBackground.swift */,
+			);
+			path = Home;
 			sourceTree = "<group>";
 		};
 		630EBCCE256682D600CDFA50 /* Resropect */ = {
@@ -244,6 +254,7 @@
 		E0B9149A256158DF00F93987 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				562F698D256EBF8400C50C97 /* Home */,
 				630EBCCE256682D600CDFA50 /* Resropect */,
 				632A10B02566CF2B0085B126 /* ContentView.swift */,
 				E030BAFB256D0A5800EC18EC /* KeyWordButton.swift */,
@@ -397,6 +408,7 @@
 				630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */,
 				63A4DF14256C193400257ED2 /* CustomAlert.swift in Sources */,
 				632A107E2566BCDB0085B126 /* RetrospectView.swift in Sources */,
+				562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */,
 				6391D16C25655C960007A926 /* HunnitLogApp.swift in Sources */,
 				630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */,
 				632A10832566BDCB0085B126 /* CardContentable.swift in Sources */,

--- a/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
+++ b/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		562F6978256A7A6D00C50C97 /* CustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6977256A7A6D00C50C97 /* CustomColor.swift */; };
 		562F697D256A7A8700C50C97 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 562F697C256A7A8700C50C97 /* Colors.xcassets */; };
 		562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6996256EC04800C50C97 /* RoundedBackground.swift */; };
+		562F69A4256EC24800C50C97 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A3256EC24800C50C97 /* ProgressBar.swift */; };
 		630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */; };
 		630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD212566A38700CDFA50 /* RetrospectRow.swift */; };
 		630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */; };
@@ -53,6 +54,7 @@
 		562F6977256A7A6D00C50C97 /* CustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomColor.swift; sourceTree = "<group>"; };
 		562F697C256A7A8700C50C97 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Colors.xcassets; path = HunnitLog/Colors.xcassets; sourceTree = SOURCE_ROOT; };
 		562F6996256EC04800C50C97 /* RoundedBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBackground.swift; sourceTree = "<group>"; };
+		562F69A3256EC24800C50C97 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfableGrayLine.swift; sourceTree = "<group>"; };
 		630EBD212566A38700CDFA50 /* RetrospectRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectRow.swift; sourceTree = "<group>"; };
 		630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthFlagRow.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				562F6996256EC04800C50C97 /* RoundedBackground.swift */,
+				562F69A3256EC24800C50C97 /* ProgressBar.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -416,6 +419,7 @@
 				632A10B12566CF2B0085B126 /* ContentView.swift in Sources */,
 				E0B91483256158AA00F93987 /* APIServiceError.swift in Sources */,
 				E0B91482256158AA00F93987 /* APIService.swift in Sources */,
+				562F69A4256EC24800C50C97 /* ProgressBar.swift in Sources */,
 				63A4DF3D256C1B5600257ED2 /* View+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
+++ b/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		562F6978256A7A6D00C50C97 /* CustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6977256A7A6D00C50C97 /* CustomColor.swift */; };
 		562F697D256A7A8700C50C97 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 562F697C256A7A8700C50C97 /* Colors.xcassets */; };
+		562F698F256EBFAE00C50C97 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F698E256EBFAE00C50C97 /* HomeView.swift */; };
 		562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6996256EC04800C50C97 /* RoundedBackground.swift */; };
 		562F69A4256EC24800C50C97 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A3256EC24800C50C97 /* ProgressBar.swift */; };
 		630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */; };
@@ -53,6 +54,7 @@
 /* Begin PBXFileReference section */
 		562F6977256A7A6D00C50C97 /* CustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomColor.swift; sourceTree = "<group>"; };
 		562F697C256A7A8700C50C97 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Colors.xcassets; path = HunnitLog/Colors.xcassets; sourceTree = SOURCE_ROOT; };
+		562F698E256EBFAE00C50C97 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		562F6996256EC04800C50C97 /* RoundedBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBackground.swift; sourceTree = "<group>"; };
 		562F69A3256EC24800C50C97 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfableGrayLine.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 		562F698D256EBF8400C50C97 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				562F698E256EBFAE00C50C97 /* HomeView.swift */,
 				562F6996256EC04800C50C97 /* RoundedBackground.swift */,
 				562F69A3256EC24800C50C97 /* ProgressBar.swift */,
 			);
@@ -411,6 +414,7 @@
 				630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */,
 				63A4DF14256C193400257ED2 /* CustomAlert.swift in Sources */,
 				632A107E2566BCDB0085B126 /* RetrospectView.swift in Sources */,
+				562F698F256EBFAE00C50C97 /* HomeView.swift in Sources */,
 				562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */,
 				6391D16C25655C960007A926 /* HunnitLogApp.swift in Sources */,
 				630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */,

--- a/HunnitLog/HunnitLog/Extension/View+Extension.swift
+++ b/HunnitLog/HunnitLog/Extension/View+Extension.swift
@@ -23,3 +23,21 @@ extension View {
         return self
     }
 }
+// MARK: - RoundedCorner
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+struct RoundedCorner: Shape {
+
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/HunnitLog/HunnitLog/View/Home/HomeView.swift
+++ b/HunnitLog/HunnitLog/View/Home/HomeView.swift
@@ -1,0 +1,32 @@
+//
+//  HomeView.swift
+//  HunnitLog
+//
+//  Created by 초이 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    
+    var body: some View {
+        ZStack{
+            CustomColor.bgColor
+            VStack{
+                ZStack{
+                    CustomColor.bgColor
+                    RoundedBackground()
+                    ProgressBar()
+                }
+                .frame(width: UIScreen.main.bounds.width, height: 250)
+                .edgesIgnoringSafeArea(.top)
+            }
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}

--- a/HunnitLog/HunnitLog/View/Home/ProgressBar.swift
+++ b/HunnitLog/HunnitLog/View/Home/ProgressBar.swift
@@ -1,0 +1,70 @@
+//
+//  ProgressBar.swift
+//  HunnitLog
+//
+//  Created by 초이 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct ProgressBar: View{
+    @State private var progressValue = 25.0
+    @State private var progressTotal = 100.0
+    
+    var body: some View {
+        VStack{
+            Text("D-78")
+                .font(.system(size: 30))
+                .fontWeight(.semibold)
+                .frame(height:47)
+                .padding(.top, 28)
+            Text("다음 회고: 20.11.16 월")
+                .font(.system(size: 12))
+                .fontWeight(.medium)
+                .foregroundColor(.gray)
+            ProgressView(value: progressValue, total: progressTotal)
+                .padding(.horizontal, 33)
+                .padding(.top, 27)
+                .progressViewStyle(HoneyBeeProgressViewStyle(value: $progressValue, total: $progressTotal))
+            HStack{
+                Text("조금만 더 힘내요! 현재 25% 달성했어요.")
+                    .font(.system(size: 13))
+                Spacer()
+            }
+            .padding(.horizontal, 33)
+        }
+    }
+}
+
+struct HoneyBeeProgressViewStyle: ProgressViewStyle {
+    @Binding var value: Double
+    @Binding var total: Double
+    
+    func makeBody(configuration: Configuration) -> some View {
+        let offset = CGFloat(value) / 100
+        return GeometryReader{ geometry in
+            VStack(spacing:0){
+                HStack{
+                    Text("🐝")
+                        .font(.system(size: 21))
+                        .scaleEffect(x: -1, y: 1, anchor: .center)
+                        .frame(width: CGFloat(geometry.size.width * offset + 15), height: 30, alignment: .bottomTrailing)
+                    Spacer()
+                    Text("🍯")
+                        .font(.system(size: 23))
+                        .frame(width: 24, height: 30, alignment: .bottomTrailing)
+                }
+                ProgressView(configuration)
+                    .accentColor(CustomColor.yellow)
+            }
+        }
+        .frame(height: 40)
+    }
+}
+
+struct ProgressBar_Previews: PreviewProvider {
+    static var previews: some View {
+        ProgressBar()
+    }
+}
+

--- a/HunnitLog/HunnitLog/View/Home/RoundedBackground.swift
+++ b/HunnitLog/HunnitLog/View/Home/RoundedBackground.swift
@@ -1,0 +1,27 @@
+//
+//  RoundedBackground.swift
+//  HunnitLog
+//
+//  Created by 초이 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct RoundedBackground: View {
+    var body: some View {
+        VStack{
+            Rectangle()
+                .fill(Color.white)
+                .frame(width: UIScreen.main.bounds.width)
+                .cornerRadius(50, corners: [.bottomRight, .bottomLeft])
+                .shadow(color: Color.init(.displayP3, red: 80/255, green: 80/255, blue: 80/255, opacity: 0.15), radius: 6, x: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, y: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/)
+                .edgesIgnoringSafeArea(.top)
+        }
+    }
+}
+
+struct RoundedBackground_Previews: PreviewProvider {
+    static var previews: some View {
+        RoundedBackground()
+    }
+}


### PR DESCRIPTION
### Description
1. 특정 모서리를 round 처리하는 Extension을 추가했습니다.
`.cornerRadius(50, corners: [.bottomRight, .bottomLeft])`와 같이 사용할 수 있습니다.
RoundedBackground에서 사용했습니다.

2. Progress Bar를 작성했습니다.
![image](https://user-images.githubusercontent.com/28949235/100259636-c3fc8d00-2f8b-11eb-888a-3a472620a106.png)
RoundedBackground 위에 존재합니다.

3. HomeView 의 top부분을 먼저 작성하여 업로드하였습니다.
RoundedBackground 뷰와 Progress Bar 뷰를 따로 분리하여 작성하고, HomeView에서 사용했습니다.
