### PR TITLE
[NON_ISSUE] 홈 목표 List 작성

### DIFF
--- a/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
+++ b/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6996256EC04800C50C97 /* RoundedBackground.swift */; };
 		562F69A4256EC24800C50C97 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A3256EC24800C50C97 /* ProgressBar.swift */; };
 		562F69A9256ECA0E00C50C97 /* DateSelectionVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */; };
+		562F69B3256ECC3A00C50C97 /* GoalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69B2256ECC3A00C50C97 /* GoalRow.swift */; };
 		630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */; };
 		630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD212566A38700CDFA50 /* RetrospectRow.swift */; };
 		630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */; };
@@ -59,6 +60,7 @@
 		562F6996256EC04800C50C97 /* RoundedBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBackground.swift; sourceTree = "<group>"; };
 		562F69A3256EC24800C50C97 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSelectionVIew.swift; sourceTree = "<group>"; };
+		562F69B2256ECC3A00C50C97 /* GoalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalRow.swift; sourceTree = "<group>"; };
 		630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfableGrayLine.swift; sourceTree = "<group>"; };
 		630EBD212566A38700CDFA50 /* RetrospectRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectRow.swift; sourceTree = "<group>"; };
 		630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthFlagRow.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				562F6996256EC04800C50C97 /* RoundedBackground.swift */,
 				562F69A3256EC24800C50C97 /* ProgressBar.swift */,
 				562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */,
+				562F69B2256ECC3A00C50C97 /* GoalRow.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -408,6 +411,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				562F69B3256ECC3A00C50C97 /* GoalRow.swift in Sources */,
 				E030BAFC256D0A5800EC18EC /* KeyWordButton.swift in Sources */,
 				632A10762566B9EB0085B126 /* AchievementRow.swift in Sources */,
 				632A106E2566B94C0085B126 /* ShadowCard.swift in Sources */,

--- a/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
+++ b/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6996256EC04800C50C97 /* RoundedBackground.swift */; };
 		562F69A4256EC24800C50C97 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A3256EC24800C50C97 /* ProgressBar.swift */; };
 		562F69A9256ECA0E00C50C97 /* DateSelectionVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */; };
+		562F69AE256ECBD400C50C97 /* AchievedGoalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69AD256ECBD400C50C97 /* AchievedGoalRow.swift */; };
 		562F69B3256ECC3A00C50C97 /* GoalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69B2256ECC3A00C50C97 /* GoalRow.swift */; };
 		630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */; };
 		630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD212566A38700CDFA50 /* RetrospectRow.swift */; };
@@ -60,6 +61,7 @@
 		562F6996256EC04800C50C97 /* RoundedBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBackground.swift; sourceTree = "<group>"; };
 		562F69A3256EC24800C50C97 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSelectionVIew.swift; sourceTree = "<group>"; };
+		562F69AD256ECBD400C50C97 /* AchievedGoalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievedGoalRow.swift; sourceTree = "<group>"; };
 		562F69B2256ECC3A00C50C97 /* GoalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalRow.swift; sourceTree = "<group>"; };
 		630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfableGrayLine.swift; sourceTree = "<group>"; };
 		630EBD212566A38700CDFA50 /* RetrospectRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectRow.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				562F69A3256EC24800C50C97 /* ProgressBar.swift */,
 				562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */,
 				562F69B2256ECC3A00C50C97 /* GoalRow.swift */,
+				562F69AD256ECBD400C50C97 /* AchievedGoalRow.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 				63A4DF25256C1B0700257ED2 /* CustomAlertViewController.swift in Sources */,
 				630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */,
 				562F6978256A7A6D00C50C97 /* CustomColor.swift in Sources */,
+				562F69AE256ECBD400C50C97 /* AchievedGoalRow.swift in Sources */,
 				562F69A9256ECA0E00C50C97 /* DateSelectionVIew.swift in Sources */,
 				630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */,
 				63A4DF14256C193400257ED2 /* CustomAlert.swift in Sources */,

--- a/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
+++ b/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		562F698F256EBFAE00C50C97 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F698E256EBFAE00C50C97 /* HomeView.swift */; };
 		562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F6996256EC04800C50C97 /* RoundedBackground.swift */; };
 		562F69A4256EC24800C50C97 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A3256EC24800C50C97 /* ProgressBar.swift */; };
+		562F69A9256ECA0E00C50C97 /* DateSelectionVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */; };
 		630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */; };
 		630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD212566A38700CDFA50 /* RetrospectRow.swift */; };
 		630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */; };
@@ -57,6 +58,7 @@
 		562F698E256EBFAE00C50C97 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		562F6996256EC04800C50C97 /* RoundedBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedBackground.swift; sourceTree = "<group>"; };
 		562F69A3256EC24800C50C97 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
+		562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSelectionVIew.swift; sourceTree = "<group>"; };
 		630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfableGrayLine.swift; sourceTree = "<group>"; };
 		630EBD212566A38700CDFA50 /* RetrospectRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectRow.swift; sourceTree = "<group>"; };
 		630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthFlagRow.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 				562F698E256EBFAE00C50C97 /* HomeView.swift */,
 				562F6996256EC04800C50C97 /* RoundedBackground.swift */,
 				562F69A3256EC24800C50C97 /* ProgressBar.swift */,
+				562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -411,6 +414,7 @@
 				63A4DF25256C1B0700257ED2 /* CustomAlertViewController.swift in Sources */,
 				630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */,
 				562F6978256A7A6D00C50C97 /* CustomColor.swift in Sources */,
+				562F69A9256ECA0E00C50C97 /* DateSelectionVIew.swift in Sources */,
 				630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */,
 				63A4DF14256C193400257ED2 /* CustomAlert.swift in Sources */,
 				632A107E2566BCDB0085B126 /* RetrospectView.swift in Sources */,

--- a/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
+++ b/HunnitLog/HunnitLog.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		562F69A9256ECA0E00C50C97 /* DateSelectionVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */; };
 		562F69AE256ECBD400C50C97 /* AchievedGoalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69AD256ECBD400C50C97 /* AchievedGoalRow.swift */; };
 		562F69B3256ECC3A00C50C97 /* GoalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69B2256ECC3A00C50C97 /* GoalRow.swift */; };
+		562F69BB256ECCC400C50C97 /* GoalList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F69BA256ECCC400C50C97 /* GoalList.swift */; };
 		630EBD102566954500CDFA50 /* HalfableGrayLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */; };
 		630EBD222566A38800CDFA50 /* RetrospectRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD212566A38700CDFA50 /* RetrospectRow.swift */; };
 		630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */; };
@@ -63,6 +64,7 @@
 		562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSelectionVIew.swift; sourceTree = "<group>"; };
 		562F69AD256ECBD400C50C97 /* AchievedGoalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievedGoalRow.swift; sourceTree = "<group>"; };
 		562F69B2256ECC3A00C50C97 /* GoalRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalRow.swift; sourceTree = "<group>"; };
+		562F69BA256ECCC400C50C97 /* GoalList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalList.swift; sourceTree = "<group>"; };
 		630EBD0F2566954500CDFA50 /* HalfableGrayLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfableGrayLine.swift; sourceTree = "<group>"; };
 		630EBD212566A38700CDFA50 /* RetrospectRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectRow.swift; sourceTree = "<group>"; };
 		630EBD2E2566A5F300CDFA50 /* MonthFlagRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthFlagRow.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 				562F69A8256ECA0E00C50C97 /* DateSelectionVIew.swift */,
 				562F69B2256ECC3A00C50C97 /* GoalRow.swift */,
 				562F69AD256ECBD400C50C97 /* AchievedGoalRow.swift */,
+				562F69BA256ECCC400C50C97 /* GoalList.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				562F6997256EC04800C50C97 /* RoundedBackground.swift in Sources */,
 				6391D16C25655C960007A926 /* HunnitLogApp.swift in Sources */,
 				630EBD2F2566A5F300CDFA50 /* MonthFlagRow.swift in Sources */,
+				562F69BB256ECCC400C50C97 /* GoalList.swift in Sources */,
 				632A10832566BDCB0085B126 /* CardContentable.swift in Sources */,
 				E0B91481256158AA00F93987 /* Tracker.swift in Sources */,
 				632A10B12566CF2B0085B126 /* ContentView.swift in Sources */,

--- a/HunnitLog/HunnitLog/Extension/View+Extension.swift
+++ b/HunnitLog/HunnitLog/Extension/View+Extension.swift
@@ -41,3 +41,12 @@ struct RoundedCorner: Shape {
         return Path(path.cgPath)
     }
 }
+
+// MARK: - addRoundedBorder
+extension View {
+    public func addRoundedBorder<S>(_ content: S, width: CGFloat = 1, cornerRadius: CGFloat) -> some View where S : ShapeStyle {
+        let roundedRect = RoundedRectangle(cornerRadius: cornerRadius)
+        return clipShape(roundedRect)
+             .overlay(roundedRect.strokeBorder(content, lineWidth: width))
+    }
+}

--- a/HunnitLog/HunnitLog/Extension/View+Extension.swift
+++ b/HunnitLog/HunnitLog/Extension/View+Extension.swift
@@ -42,9 +42,9 @@ struct RoundedCorner: Shape {
     }
 }
 
-// MARK: - addRoundedBorder
+// MARK: - makeRoundedWithBorder
 extension View {
-    public func addRoundedBorder<S>(_ content: S, width: CGFloat = 1, cornerRadius: CGFloat) -> some View where S : ShapeStyle {
+    public func makeRoundedWithBorder<S>(_ content: S, width: CGFloat = 1, cornerRadius: CGFloat) -> some View where S : ShapeStyle {
         let roundedRect = RoundedRectangle(cornerRadius: cornerRadius)
         return clipShape(roundedRect)
              .overlay(roundedRect.strokeBorder(content, lineWidth: width))

--- a/HunnitLog/HunnitLog/View/Home/AchievedGoalRow.swift
+++ b/HunnitLog/HunnitLog/View/Home/AchievedGoalRow.swift
@@ -40,7 +40,7 @@ struct AchievedGoalRow: View {
         .padding(.horizontal, 18)
         .padding(.vertical, 15)
         .background(CustomColor.yellow)
-        .addRoundedBorder(CustomColor.gray, width:0.3, cornerRadius: 13)
+        .makeRoundedWithBorder(CustomColor.gray, width:0.3, cornerRadius: 13)
     }
 }
 

--- a/HunnitLog/HunnitLog/View/Home/AchievedGoalRow.swift
+++ b/HunnitLog/HunnitLog/View/Home/AchievedGoalRow.swift
@@ -12,8 +12,8 @@ struct AchievedGoalRow: View {
     let achievement: Int
     
     var body: some View {
-        HStack(spacing: 7){
-            ZStack{
+        HStack(spacing: 7) {
+            ZStack {
                 Circle()
                     .fill(Color.white)
                     .frame(width: 47, height: 47)
@@ -21,13 +21,13 @@ struct AchievedGoalRow: View {
                     .font(.system(size: 22))
             }
             .padding(.trailing, 10)
-            VStack{
-                HStack{
+            VStack {
+                HStack {
                     Text(title)
                         .font(.system(size: 17))
                         Spacer()
                 }
-                HStack{
+                HStack {
                     Text("달성률 \(achievement)%")
                         .font(.system(size: 13))
                         .foregroundColor(CustomColor.coolGray)

--- a/HunnitLog/HunnitLog/View/Home/AchievedGoalRow.swift
+++ b/HunnitLog/HunnitLog/View/Home/AchievedGoalRow.swift
@@ -1,0 +1,51 @@
+//
+//  AchievedGoalRow.swift
+//  HunnitLog
+//
+//  Created by 초이 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct AchievedGoalRow: View {
+    let title: String
+    let achievement: Int
+    
+    var body: some View {
+        HStack(spacing: 7){
+            ZStack{
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 47, height: 47)
+                Text("👍")
+                    .font(.system(size: 22))
+            }
+            .padding(.trailing, 10)
+            VStack{
+                HStack{
+                    Text(title)
+                        .font(.system(size: 17))
+                        Spacer()
+                }
+                HStack{
+                    Text("달성률 \(achievement)%")
+                        .font(.system(size: 13))
+                        .foregroundColor(CustomColor.coolGray)
+                    Spacer()
+                }
+            }
+            Image(systemName: "chevron.down")
+                .foregroundColor(CustomColor.darkGray)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 15)
+        .background(CustomColor.yellow)
+        .addRoundedBorder(CustomColor.gray, width:0.3, cornerRadius: 13)
+    }
+}
+
+struct AchievedGoalRow_Previews: PreviewProvider {
+    static var previews: some View {
+        AchievedGoalRow(title: "목표제목입니다목표제목입니다목표제목입니다목표제목입니다목표제목입니다", achievement: 100)
+    }
+}

--- a/HunnitLog/HunnitLog/View/Home/DateSelectionVIew.swift
+++ b/HunnitLog/HunnitLog/View/Home/DateSelectionVIew.swift
@@ -48,8 +48,7 @@ struct buttonBackGroundView: View {
     var body: some View {
         Rectangle()
             .fill(Color.white)
-            .cornerRadius(5)
-            .addRoundedBorder(CustomColor.gray, width: 0.4, cornerRadius: 5)
+            .makeRoundedWithBorder(CustomColor.gray, width: 0.4, cornerRadius: 5)
     }
 }
 

--- a/HunnitLog/HunnitLog/View/Home/DateSelectionVIew.swift
+++ b/HunnitLog/HunnitLog/View/Home/DateSelectionVIew.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct DateSelectionVIew: View {
     var body: some View {
-        HStack{
+        HStack {
             Button(action: {
                 
             }, label: {
@@ -27,11 +27,11 @@ struct DateSelectionVIew: View {
             Button(action: dosth){
                 Text("편집")
             }
-            .buttonStyle(homeButtonStyle())
+            .buttonStyle(homeButtonStyle(horizontalPadding: 10))
             Button(action: dosth){
                 Text("점수입력")
             }
-            .buttonStyle(homeButtonStyle())
+            .buttonStyle(homeButtonStyle(horizontalPadding: 6))
         }
         .padding(.horizontal, 33)
     }
@@ -44,7 +44,7 @@ func dosth(){
 }
 
 
-struct buttonBackGroundView: View{
+struct buttonBackGroundView: View {
     var body: some View {
         Rectangle()
             .fill(Color.white)
@@ -53,11 +53,12 @@ struct buttonBackGroundView: View{
     }
 }
 
-struct homeButtonStyle: ButtonStyle{
+struct homeButtonStyle: ButtonStyle {
+    var horizontalPadding: Int
     func makeBody(configuration: Configuration) -> some View {
             configuration.label
                 .font(.system(size: 12))
-                .padding(.horizontal, 6)
+                .padding(.horizontal, CGFloat(horizontalPadding))
                 .padding(.vertical, 5)
                 .foregroundColor(CustomColor.darkGray)
                 .background(buttonBackGroundView())

--- a/HunnitLog/HunnitLog/View/Home/DateSelectionVIew.swift
+++ b/HunnitLog/HunnitLog/View/Home/DateSelectionVIew.swift
@@ -1,0 +1,71 @@
+//
+//  DateSelectionVIew.swift
+//  HunnitLog
+//
+//  Created by 초이 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct DateSelectionVIew: View {
+    var body: some View {
+        HStack{
+            Button(action: {
+                
+            }, label: {
+                HStack(spacing: 8){
+                    Text("2020.11.05")
+                        .foregroundColor(.black)
+                        .font(.system(size: 18))
+                    Image(systemName: "arrowtriangle.down.fill")
+                        .resizable()
+                        .frame(width: 9, height: 7)
+                        .foregroundColor(.black)
+                }
+            })
+            Spacer()
+            Button(action: dosth){
+                Text("편집")
+            }
+            .buttonStyle(homeButtonStyle())
+            Button(action: dosth){
+                Text("점수입력")
+            }
+            .buttonStyle(homeButtonStyle())
+        }
+        .padding(.horizontal, 33)
+    }
+}
+
+
+// MARK: - fake action function
+func dosth(){
+    print("a")
+}
+
+
+struct buttonBackGroundView: View{
+    var body: some View {
+        Rectangle()
+            .fill(Color.white)
+            .cornerRadius(5)
+            .addRoundedBorder(CustomColor.gray, width: 0.4, cornerRadius: 5)
+    }
+}
+
+struct homeButtonStyle: ButtonStyle{
+    func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .font(.system(size: 12))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 5)
+                .foregroundColor(CustomColor.darkGray)
+                .background(buttonBackGroundView())
+    }
+}
+
+struct DateSelectionVIew_Previews: PreviewProvider {
+    static var previews: some View {
+        DateSelectionVIew()
+    }
+}

--- a/HunnitLog/HunnitLog/View/Home/GoalList.swift
+++ b/HunnitLog/HunnitLog/View/Home/GoalList.swift
@@ -1,0 +1,58 @@
+//
+//  GoalList.swift
+//  HunnitLog
+//
+//  Created by 초이 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct GoalList: View {
+    // MARK: - 더미데이터
+    @State private var goals = [
+        goal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 25),
+        goal(title: "운전면허증 따기", achievement: 25),
+        goal(title: "토익 900점 찍기", achievement: 20),
+        goal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 30)
+    ]
+    
+    @State private var achievedGoals = [
+        achievedGoal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 100),
+        achievedGoal(title: "토익 900점 찍기", achievement: 100),
+        achievedGoal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 100)
+    ]
+    
+    // MARK: - body
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(goals, id:\.self) { obj in
+                    GoalRow(title: obj.title, achievement: obj.achievement)
+                }
+                ForEach(achievedGoals, id:\.self) { obj in
+                    AchievedGoalRow(title: obj.title, achievement: obj.achievement)
+                }
+            }
+        }
+        .padding(.horizontal, 33)
+    }
+}
+
+// MARK: - 더미데이터 구조체
+struct goal: Hashable {
+    var title = ""
+    var achievement = 0
+    var id = UUID()
+}
+
+struct achievedGoal: Hashable {
+    var title = ""
+    var achievement = 0
+    var id = UUID()
+}
+
+struct GoalList_Previews: PreviewProvider {
+    static var previews: some View {
+        GoalList()
+    }
+}

--- a/HunnitLog/HunnitLog/View/Home/GoalList.swift
+++ b/HunnitLog/HunnitLog/View/Home/GoalList.swift
@@ -10,27 +10,27 @@ import SwiftUI
 struct GoalList: View {
     // MARK: - 더미데이터
     @State private var goals = [
-        goal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 25),
-        goal(title: "운전면허증 따기", achievement: 25),
-        goal(title: "토익 900점 찍기", achievement: 20),
-        goal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 30)
+        Goal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 25),
+        Goal(title: "운전면허증 따기", achievement: 25),
+        Goal(title: "토익 900점 찍기", achievement: 20),
+        Goal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 30)
     ]
     
     @State private var achievedGoals = [
-        achievedGoal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 100),
-        achievedGoal(title: "토익 900점 찍기", achievement: 100),
-        achievedGoal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 100)
+        AchievedGoal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 100),
+        AchievedGoal(title: "토익 900점 찍기", achievement: 100),
+        AchievedGoal(title: "올해 안에 연애하기라랄ㄹ라 라라아아아아아아아아", achievement: 100)
     ]
     
     // MARK: - body
     var body: some View {
         ScrollView {
             LazyVStack {
-                ForEach(goals, id:\.self) { obj in
-                    GoalRow(title: obj.title, achievement: obj.achievement)
+                ForEach(goals, id:\.self) { goal in
+                    GoalRow(title: goal.title, achievement: goal.achievement)
                 }
-                ForEach(achievedGoals, id:\.self) { obj in
-                    AchievedGoalRow(title: obj.title, achievement: obj.achievement)
+                ForEach(achievedGoals, id:\.self) { goal in
+                    AchievedGoalRow(title: goal.title, achievement: goal.achievement)
                 }
             }
         }
@@ -39,13 +39,13 @@ struct GoalList: View {
 }
 
 // MARK: - 더미데이터 구조체
-struct goal: Hashable {
+struct Goal: Hashable {
     var title = ""
     var achievement = 0
     var id = UUID()
 }
 
-struct achievedGoal: Hashable {
+struct AchievedGoal: Hashable {
     var title = ""
     var achievement = 0
     var id = UUID()

--- a/HunnitLog/HunnitLog/View/Home/GoalRow.swift
+++ b/HunnitLog/HunnitLog/View/Home/GoalRow.swift
@@ -13,20 +13,20 @@ struct GoalRow: View {
     
     
     var body: some View {
-        HStack(spacing: 7){
+        HStack(spacing: 7) {
             Circle()
                 .stroke(CustomColor.gray, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round, dash: [3,5]))
                 .frame(width: 47, height: 47)
                 .background(Circle().foregroundColor(CustomColor.bgColor))
                 .padding(.trailing, 10)
                 
-            VStack{
-                HStack{
+            VStack {
+                HStack {
                     Text(title)
                         .font(.system(size: 17))
                         Spacer()
                 }
-                HStack{
+                HStack {
                     Text("달성률 \(achievement)%")
                         .font(.system(size: 13))
                         .foregroundColor(CustomColor.coolGray)

--- a/HunnitLog/HunnitLog/View/Home/GoalRow.swift
+++ b/HunnitLog/HunnitLog/View/Home/GoalRow.swift
@@ -1,0 +1,50 @@
+//
+//  GoalRow.swift
+//  HunnitLog
+//
+//  Created by 초이 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct GoalRow: View {
+    let title: String
+    let achievement: Int
+    
+    
+    var body: some View {
+        HStack(spacing: 7){
+            Circle()
+                .stroke(CustomColor.gray, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round, dash: [3,5]))
+                .frame(width: 47, height: 47)
+                .background(Circle().foregroundColor(CustomColor.bgColor))
+                .padding(.trailing, 10)
+                
+            VStack{
+                HStack{
+                    Text(title)
+                        .font(.system(size: 17))
+                        Spacer()
+                }
+                HStack{
+                    Text("달성률 \(achievement)%")
+                        .font(.system(size: 13))
+                        .foregroundColor(CustomColor.coolGray)
+                    Spacer()
+                }
+            }
+            Image(systemName: "chevron.down")
+                .foregroundColor(CustomColor.darkGray)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 15)
+        .background(Color.white)
+        .addRoundedBorder(CustomColor.gray, width:0.3, cornerRadius: 13)
+    }
+}
+
+struct GoalRow_Previews: PreviewProvider {
+    static var previews: some View {
+        GoalRow(title: "목표제목입니다목표제목입니다목표제목입니다목표제목입니다목표제목입니다", achievement: 20)
+    }
+}

--- a/HunnitLog/HunnitLog/View/Home/GoalRow.swift
+++ b/HunnitLog/HunnitLog/View/Home/GoalRow.swift
@@ -39,7 +39,7 @@ struct GoalRow: View {
         .padding(.horizontal, 18)
         .padding(.vertical, 15)
         .background(Color.white)
-        .addRoundedBorder(CustomColor.gray, width:0.3, cornerRadius: 13)
+        .makeRoundedWithBorder(CustomColor.gray, width:0.3, cornerRadius: 13)
     }
 }
 

--- a/HunnitLog/HunnitLog/View/Home/HomeView.swift
+++ b/HunnitLog/HunnitLog/View/Home/HomeView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct HomeView: View {
     
     var body: some View {
-        ZStack{
+        ZStack {
             CustomColor.bgColor
-            VStack{
-                ZStack{
+            VStack {
+                ZStack {
                     CustomColor.bgColor
                     RoundedBackground()
                     ProgressBar()

--- a/HunnitLog/HunnitLog/View/Home/HomeView.swift
+++ b/HunnitLog/HunnitLog/View/Home/HomeView.swift
@@ -20,6 +20,8 @@ struct HomeView: View {
                 }
                 .frame(width: UIScreen.main.bounds.width, height: 250)
                 .edgesIgnoringSafeArea(.top)
+                DateSelectionVIew()
+                GoalList()
             }
         }
     }

--- a/HunnitLog/HunnitLog/View/Home/ProgressBar.swift
+++ b/HunnitLog/HunnitLog/View/Home/ProgressBar.swift
@@ -7,12 +7,12 @@
 
 import SwiftUI
 
-struct ProgressBar: View{
+struct ProgressBar: View {
     @State private var progressValue = 25.0
     @State private var progressTotal = 100.0
     
     var body: some View {
-        VStack{
+        VStack {
             Text("D-78")
                 .font(.system(size: 30))
                 .fontWeight(.semibold)
@@ -26,7 +26,7 @@ struct ProgressBar: View{
                 .padding(.horizontal, 33)
                 .padding(.top, 27)
                 .progressViewStyle(HoneyBeeProgressViewStyle(value: $progressValue, total: $progressTotal))
-            HStack{
+            HStack {
                 Text("조금만 더 힘내요! 현재 25% 달성했어요.")
                     .font(.system(size: 13))
                 Spacer()
@@ -43,8 +43,8 @@ struct HoneyBeeProgressViewStyle: ProgressViewStyle {
     func makeBody(configuration: Configuration) -> some View {
         let offset = CGFloat(value) / 100
         return GeometryReader{ geometry in
-            VStack(spacing:0){
-                HStack{
+            VStack(spacing:0) {
+                HStack {
                     Text("🐝")
                         .font(.system(size: 21))
                         .scaleEffect(x: -1, y: 1, anchor: .center)

--- a/HunnitLog/HunnitLog/View/Home/RoundedBackground.swift
+++ b/HunnitLog/HunnitLog/View/Home/RoundedBackground.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct RoundedBackground: View {
     var body: some View {
-        VStack{
+        VStack {
             Rectangle()
                 .fill(Color.white)
                 .frame(width: UIScreen.main.bounds.width)


### PR DESCRIPTION
**1. round 처리된 border를 추가하는 addRoundedBorder 함수를 View Extension에 추가했습니다.**
`.addRoundedBorder(CustomColor.gray, width:0.3, cornerRadius: 13)`와 같이 사용할 수 있습니다.
DataSelectionView, GoalRow, AchievedGoalRow에서 사용했습니다.

**2 top 부분과 List 부분 사이의 날짜 설정 뷰를 작성했습니다.**
DataSelectionView
![image](https://user-images.githubusercontent.com/28949235/100263491-ea70f700-2f90-11eb-95bb-7ba1e256ca63.png)

또한 편집, 점수입력 버튼의 ButtonStyle을 `homeButtonStyle`로 정의해두었는데,  
다른 뷰에서도 사용할 일이 생기면 Style을 다른 파일로 분리하면 될 것 같습니다.
우선은 해당 뷰에서만 사용하는 것 같아 동일 파일 내에 정의해두었습니다.

**3. 목표 기본 Row와 100% 달성 시 목표 Row를 작성했습니다.**
기본(달성률 0%~99%일 시)
![image](https://user-images.githubusercontent.com/28949235/100263811-52274200-2f91-11eb-87dc-ec9f994e8866.png)

달성완료 (달성률 100%일 시)
![image](https://user-images.githubusercontent.com/28949235/100263878-69662f80-2f91-11eb-8eea-0badb925d544.png)

**4. 목표 List를 만들고, List를 Home View에 추가했습니다.**
LazyVStack을 ScrollView로 감싸 사용하여 Row간 separator 없이 구현하였습니다.